### PR TITLE
Fix navigation position validation check

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ module.exports = (app) => {
               handleState(v.value);
             }
             if (v.path === 'navigation.position') {
-              if (Number.isNaN(Number(v.value.latitude))
+              if (!v.path || Number.isNaN(Number(v.value.latitude))
                 || Number.isNaN(Number(v.value.longitude))) {
                 return;
               }


### PR DESCRIPTION
Fix unhandled exception in the log when no position is available

```
Mar 30 15:59:51 [signalk-to-nmea0183] GGA: no position, not converting
Mar 30 15:59:51 @meri-imperiumi/signalk-triplogger subscription callback error: Cannot read properties of null (reading 'latitude')
Mar 30 15:59:51 TypeError: Cannot read properties of null (reading 'latitude') at /home/pi/.signalk/node_modules/@meri-imperiumi/signalk-triplogger/index.js:184:47 at Array.forEach (<anonymous>) at /home/pi/.signalk/node_modules/@meri-imperiumi/signalk-triplogger/index.js:178:20 at Array.forEach (<anonymous>) at /home/pi/.signalk/node_modules/@meri-imperiumi/signalk-triplogger/index.js:174:23 at safeCallback (/usr/lib/node_modules/signalk-server/dist/interfaces/plugins.js:429:25) at /usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:3562:24 at /usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:516:29 at processAfters (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:405:21) at Object.inTransaction (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:494:13) at Dispatcher.push (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:2408:30) at Dispatcher.handleEvent (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:2467:25) at Buffer.push (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:77:36) at Buffer.flush (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:2636:30) at Timeout.<anonymous> (/usr/lib/node_modules/signalk-server/node_modules/baconjs/dist/Bacon.js:2655:30) at listOnTimeout (node:internal/timers:588:17) at process.processTimers (node:internal/timers:523:7)
Mar 30 15:59:52 [signalk-to-nmea0183] GGA: no position, not converting
Mar 30 15:59:52 [signalk-to-nmea0183] GGA: no position, not converting
```